### PR TITLE
app header height fix in firefox

### DIFF
--- a/src/nxt-app.html
+++ b/src/nxt-app.html
@@ -42,6 +42,7 @@
       }
       app-header {
         min-height: 50px;
+        height: 108px;
       }
     </style>
 


### PR DESCRIPTION
removed blank space below app header in firefox